### PR TITLE
Clean up stale ESP comments

### DIFF
--- a/LAMMPS/src/KSPACE/esp.cpp
+++ b/LAMMPS/src/KSPACE/esp.cpp
@@ -122,7 +122,7 @@ void ESP::settings(int narg, char **arg)
 {
   if (narg < 1) error->all(FLERR,"Illegal kspace_style {} command", force->kspace_style);
 
-  accuracy_relative = fabs(utils::numeric(FLERR, arg[0], false, lmp)); // will be used for splitting accuracy
+  accuracy_relative = fabs(utils::numeric(FLERR, arg[0], false, lmp));
 
   if (narg == 1){
     spreading_accuracy = 0.5 * accuracy_relative;
@@ -152,10 +152,6 @@ ESP::~ESP()
   if (peratom_allocate_flag) ESP::deallocate_peratom();
   if (group_allocate_flag) ESP::deallocate_groups();
   memory->destroy(part2grid);
-  // memory->destroy(force_poly_coeff);
-  // memory->destroy(energy_poly_coeff);
-  // memory->destroy(fourier_split_poly_coeff);
-  // memory->destroy(fourier_spread_poly_coeff);
 }
 
 /* ----------------------------------------------------------------------

--- a/LAMMPS/src/kspace.h
+++ b/LAMMPS/src/kspace.h
@@ -76,7 +76,7 @@ class KSpace : protected Pointers {
 
   int ewaldflag;         // 1 if a Ewald solver
   int pppmflag;          // 1 if a PPPM solver
-  int espflag;           // 1 if a ESP solver
+  int espflag;           // 1 if an ESP solver
   int msmflag;           // 1 if a MSM solver
   int dispersionflag;    // 1 if a LJ/dispersion solver
   int tip4pflag;         // 1 if a TIP4P solver

--- a/LAMMPS/src/pair.cpp
+++ b/LAMMPS/src/pair.cpp
@@ -438,9 +438,7 @@ void Pair::init_tables(double cut_coul, double *cut_respa)
       fgamma = 1.0 + ((double)rsq_lookup.f/cut_coulsq)*
         force->kspace->dgamma(r/cut_coul);
     } else if (espflag) {
-      // This block is currently empty and does not perform any operations.
-    }
-    else {
+    } else {
       grij = g_ewald * r;
       expm2 = exp(-grij*grij);
       derfc = erfc(grij);

--- a/LAMMPS/src/pair.h
+++ b/LAMMPS/src/pair.h
@@ -70,7 +70,7 @@ class Pair : protected Pointers {
 
   int ewaldflag;         // 1 if compatible with Ewald solver
   int pppmflag;          // 1 if compatible with PPPM solver
-  int espflag;           // 1 if compatible with PS solver
+  int espflag;           // 1 if compatible with ESP solver
   int msmflag;           // 1 if compatible with MSM solver
   int dispersionflag;    // 1 if compatible with LJ/dispersion solver
   int tip4pflag;         // 1 if compatible with TIP4P solver


### PR DESCRIPTION
## Summary
Clean up stale or misleading ESP-related comments in the synchronized `LAMMPS/` sources.

## Why
The previous synchronization PR has already been merged. This follow-up keeps the code comments aligned with the current ESP implementation and removes a few leftover comments that no longer reflect the code.

## Changes
- rename the old `PS solver` wording to `ESP solver`
- remove an empty explanatory comment in `pair.cpp`
- remove stale commented-out cleanup lines in `src/KSPACE/esp.cpp`
- simplify one redundant inline comment in `src/KSPACE/esp.cpp`

## Validation
No build or runtime checks were rerun for this PR because the change is comment-only and does not modify behavior.